### PR TITLE
Issue #48: bugfolder to become co-maintainer of the module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ Current Maintainers
 -------------------
 
 - jenlampton (https://github.com/jenlampton)
-- seeking additional maintainers
+- Robert J. Lang (bugfolder) (https://github.com/bugfolder)
+- Seeking additional maintainers
 
 
 Credits


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/colorbox/issues/48.